### PR TITLE
Fixes build failure with GCC6

### DIFF
--- a/src/gtextutils/text_line_reader.cpp
+++ b/src/gtextutils/text_line_reader.cpp
@@ -44,6 +44,6 @@ bool TextLineReader::next_line()
 	if (input_stream.eof())
 		return false;
 
-	return input_stream ;
+	return static_cast<bool>(input_stream) ;
 }
 


### PR DESCRIPTION
Without this patch, libgtextutils fails to build with GCC6 [1]. See [2] for further details.

[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=811646
[2] https://gcc.gnu.org/gcc-6/porting_to.html