### PR TITLE
This fixes a bug causing a compiler error.

### DIFF
--- a/src/gtextutils/text_line_reader.cpp
+++ b/src/gtextutils/text_line_reader.cpp
@@ -44,6 +44,6 @@ bool TextLineReader::next_line()
 	if (input_stream.eof())
 		return false;
 
-	return input_stream ;
+	return true ;
 }
 


### PR DESCRIPTION
In text_line_reader.cpp, the next_line() function returns an ifstream if it succeeds, but with many compilers this is not allowed to be cast to a bool. Best to return true instead. So far this works well with fastx_toolkit.